### PR TITLE
Add category/task separation for myMoment filtering

### DIFF
--- a/migrations/versions/add_task_filter_support.py
+++ b/migrations/versions/add_task_filter_support.py
@@ -1,0 +1,49 @@
+"""Add task filter support for myMoment writing tasks
+
+Revision ID: 2026011301
+Revises: ef36ae3ec41f
+Create Date: 2026-01-13 10:00:00.000000
+
+This migration adds support for filtering by writing tasks (Aufgaben) in addition to categories.
+myMoment now separates categories (Kategorien) from writing tasks (Aufgaben), allowing
+more granular filtering.
+
+Changes:
+- Add task_filter to monitoring_processes table
+- Add article_task_id to ai_comments table
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '2026011301'
+down_revision = 'ef36ae3ec41f'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """
+    Add task_filter column to monitoring_processes and article_task_id to ai_comments.
+    """
+    # Add task_filter to monitoring_processes
+    with op.batch_alter_table('monitoring_processes', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('task_filter', sa.Integer(), nullable=True))
+
+    # Add article_task_id to ai_comments
+    with op.batch_alter_table('ai_comments', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('article_task_id', sa.Integer(), nullable=True))
+
+
+def downgrade() -> None:
+    """
+    Remove task_filter from monitoring_processes and article_task_id from ai_comments.
+    """
+    # Remove task_filter from monitoring_processes
+    with op.batch_alter_table('monitoring_processes', schema=None) as batch_op:
+        batch_op.drop_column('task_filter')
+
+    # Remove article_task_id from ai_comments
+    with op.batch_alter_table('ai_comments', schema=None) as batch_op:
+        batch_op.drop_column('article_task_id')

--- a/src/api/monitoring_processes.py
+++ b/src/api/monitoring_processes.py
@@ -54,6 +54,12 @@ async def create_monitoring_process(
             if isinstance(categories, list) and categories:
                 category_filter = categories[0]
 
+        task_filter = target_filters.get("task")
+        if task_filter is None:
+            tasks = target_filters.get("tasks")
+            if isinstance(tasks, list) and tasks:
+                task_filter = tasks[0]
+
         tab_filter = target_filters.get("tab")
         if tab_filter is None:
             tabs = target_filters.get("tabs")
@@ -69,6 +75,7 @@ async def create_monitoring_process(
             name=process_data.name,
             description=process_data.description,
             category_filter=category_filter,
+            task_filter=task_filter,
             search_filter=target_filters.get("search"),
             tab_filter=tab_filter,
             sort_option=target_filters.get("sort"),
@@ -224,6 +231,12 @@ async def update_monitoring_process(
             if isinstance(categories, list) and categories:
                 category_filter = categories[0]
 
+        task_filter = target_filters.get("task")
+        if task_filter is None:
+            tasks = target_filters.get("tasks")
+            if isinstance(tasks, list) and tasks:
+                task_filter = tasks[0]
+
         tab_filter = target_filters.get("tab")
         if tab_filter is None:
             tabs = target_filters.get("tabs")
@@ -254,6 +267,8 @@ async def update_monitoring_process(
         # Add filter fields if provided
         if category_filter is not None:
             update_kwargs['category_filter'] = category_filter
+        if task_filter is not None:
+            update_kwargs['task_filter'] = task_filter
         if process_data.target_filters is not None:
             if 'search' in target_filters:
                 update_kwargs['search_filter'] = target_filters['search']

--- a/src/models/ai_comment.py
+++ b/src/models/ai_comment.py
@@ -92,6 +92,7 @@ class AIComment(BaseModel):
     article_title = Column(Text, nullable=False)
     article_author = Column(String(200), nullable=False)
     article_category = Column(Integer, nullable=True)  # myMoment category ID
+    article_task_id = Column(Integer, nullable=True)  # myMoment task/Aufgabe ID
     article_url = Column(String(500), nullable=False)  # myMoment article URL
 
     # Article content (frozen snapshot)
@@ -323,6 +324,7 @@ class AIComment(BaseModel):
             "title": self.article_title,
             "author": self.article_author,
             "category": self.article_category,
+            "task_id": self.article_task_id,
             "url": self.article_url,
             "content": self.article_content,
             "raw_html": self.article_raw_html,

--- a/src/models/monitoring_process.py
+++ b/src/models/monitoring_process.py
@@ -36,6 +36,7 @@ class MonitoringProcess(BaseModel):
 
     # Monitoring criteria
     category_filter = Column(Integer, nullable=True)  # myMoment category ID
+    task_filter = Column(Integer, nullable=True)  # myMoment task/Aufgabe ID
     search_filter = Column(String(200), nullable=True)  # Search terms
     tab_filter = Column(String(50), nullable=True)  # myMoment tab / class id
     sort_option = Column(String(50), nullable=True)  # Sort criteria
@@ -153,6 +154,8 @@ class MonitoringProcess(BaseModel):
         filters = {}
         if self.category_filter is not None:
             filters['category'] = self.category_filter
+        if self.task_filter is not None:
+            filters['task'] = self.task_filter
         if self.search_filter:
             filters['search'] = self.search_filter
         if self.tab_filter:

--- a/src/services/monitoring_service.py
+++ b/src/services/monitoring_service.py
@@ -121,6 +121,7 @@ class MonitoringService:
         name: str,
         description: Optional[str] = None,
         category_filter: Optional[int] = None,
+        task_filter: Optional[int] = None,
         search_filter: Optional[str] = None,
         tab_filter: Optional[str] = None,
         sort_option: Optional[str] = None,
@@ -138,7 +139,8 @@ class MonitoringService:
             user_id: User creating the process
             name: Process name
             description: Optional process description
-            category_filter: Optional myMoment category filter
+            category_filter: Optional myMoment category filter (by category ID)
+            task_filter: Optional myMoment task filter (by task ID)
             search_filter: Optional search terms
             tab_filter: Optional tab filter (new, popular, etc.)
             sort_option: Optional sort criteria
@@ -192,6 +194,7 @@ class MonitoringService:
                 name=name,
                 description=description,
                 category_filter=category_filter,
+                task_filter=task_filter,
                 search_filter=search_filter,
                 tab_filter=tab_filter,
                 sort_option=sort_option,
@@ -247,6 +250,7 @@ class MonitoringService:
         name: Optional[str] = None,
         description: Optional[str] = None,
         category_filter: Optional[int] = None,
+        task_filter: Optional[int] = None,
         search_filter: Optional[str] = None,
         tab_filter: Optional[str] = None,
         sort_option: Optional[str] = None,
@@ -265,6 +269,7 @@ class MonitoringService:
             name: New process name (optional)
             description: New process description (optional)
             category_filter: New category filter (optional)
+            task_filter: New task filter (optional)
             search_filter: New search filter (optional)
             tab_filter: New tab filter (optional)
             sort_option: New sort option (optional)
@@ -304,6 +309,8 @@ class MonitoringService:
             # Update filter fields
             if category_filter is not None:
                 process.category_filter = category_filter
+            if task_filter is not None:
+                process.task_filter = task_filter
             if search_filter is not None:
                 process.search_filter = search_filter
             if tab_filter is not None:

--- a/src/tasks/article_discovery.py
+++ b/src/tasks/article_discovery.py
@@ -42,6 +42,7 @@ class ProcessConfig:
     llm_provider_id: Optional[uuid.UUID]
     tab_filter: Optional[str]
     category_filter: Optional[int]
+    task_filter: Optional[int]
     search_filter: Optional[str]
 
 
@@ -130,6 +131,7 @@ class ArticleDiscoveryTask(BaseTask):
                 llm_provider_id=llm_provider_id,
                 tab_filter=process.tab_filter,
                 category_filter=process.category_filter,
+                task_filter=process.task_filter,
                 search_filter=process.search_filter
             )
 
@@ -197,6 +199,7 @@ class ArticleDiscoveryTask(BaseTask):
 
                     tab = config_snapshot.tab_filter
                     category = str(config_snapshot.category_filter) if config_snapshot.category_filter else None
+                    task = str(config_snapshot.task_filter) if config_snapshot.task_filter else None
                     search = config_snapshot.search_filter
                     limit = 20  # Default articles per login
 
@@ -204,6 +207,7 @@ class ArticleDiscoveryTask(BaseTask):
                         context=context,
                         tab=tab,
                         category=category,
+                        task=task,
                         search=search,
                         limit=limit
                     )
@@ -266,6 +270,7 @@ class ArticleDiscoveryTask(BaseTask):
                         article_title=article_meta.title,
                         article_author=article_meta.author,
                         article_category=article_meta.category_id,
+                        article_task_id=article_meta.task_id,
                         article_url=article_meta.url,
                         article_edited_at=None,  # Not available from index
                         article_scraped_at=datetime.utcnow(),

--- a/src/tasks/article_preparation.py
+++ b/src/tasks/article_preparation.py
@@ -188,6 +188,12 @@ class ArticlePreparationTask(BaseTask):
                 if 'title' in content_data:
                     ai_comment.article_title = content_data['title']
 
+                # Update category and task IDs extracted from detail page
+                if 'category_id' in content_data and content_data['category_id'] is not None:
+                    ai_comment.article_category = content_data['category_id']
+                if 'task_id' in content_data and content_data['task_id'] is not None:
+                    ai_comment.article_task_id = content_data['task_id']
+
                 # Note: article_published_at is not available from scraper yet
                 # It would need to be added to ScraperService.get_article_content()
 

--- a/templates/monitoring_processes/form.html
+++ b/templates/monitoring_processes/form.html
@@ -78,7 +78,7 @@
                     <div class="mt-3">
                         <label class="form-label">Filter für myMoment Artikel</label>
                         <div class="row g-2">
-                            <div class="col-md-4">
+                            <div class="col-md-3">
                                 <label for="tabFilter" class="form-label small">
                                     Tab
                                     <span id="tabLoadingIndicator" class="spinner-border spinner-border-sm ms-2" style="display: none;" role="status">
@@ -90,24 +90,28 @@
                                 </select>
                                 <div class="form-text" id="tabFilterHelp">Wähle myMoment-Zugangsdaten, um verfügbare Klasse zu laden</div>
                             </div>
-                            <div class="col-md-4">
+                            <div class="col-md-3">
                                 <label for="categoryFilter" class="form-label small">Kategorie</label>
                                 <select id="categoryFilter" class="form-select">
                                     <option value="">Alle Kategorien</option>
-                                    <option value="9">Unterhalten</option>
-                                    <option value="7">Informieren</option>
                                     <option value="4">Anleiten</option>
                                     <option value="14">Berichten</option>
                                     <option value="5">Erklären</option>
                                     <option value="6">Fragen</option>
+                                    <option value="7">Informieren</option>
                                     <option value="8">Überzeugen</option>
-                                    <option value="12">Schreibaufgabe: Schaltplan</option>
-                                    <option value="11">Schreibaufgabe: Wegbeschreibung</option>
-                                    <option value="10">Schreibaufgabe: Fiktionaler Dialog</option>
-                                    <option value="13">Schreibaufgabe: Reisebericht</option>
+                                    <option value="9">Unterhalten</option>
                                 </select>
                             </div>
-                            <div class="col-md-4">
+                            <div class="col-md-3">
+                                <label for="taskFilter" class="form-label small">Schreibaufgabe</label>
+                                <select id="taskFilter" class="form-select">
+                                    <option value="">Alle Aufgaben</option>
+                                    <option value="4">Fiktionaler Dialog zwischen zwei Gegenständen</option>
+                                    <option value="10">Wo ist Hugo? (Anleitung schreiben)</option>
+                                </select>
+                            </div>
+                            <div class="col-md-3">
                                 <label for="searchFilter" class="form-label small">Suchbegriff</label>
                                 <input type="text" id="searchFilter" class="form-control" placeholder="Stichwörter" disabled>
                                 <div class="form-text">Optionale Filter, um Artikel mit bestimmten Titeln auf myMoment anzusteuern (derzeit nicht verfügbar)</div>
@@ -185,6 +189,7 @@ document.addEventListener('DOMContentLoaded', async function() {
     const promptSelect = document.getElementById('promptTemplates');
     const loginSelect = document.getElementById('loginIds');
     const categoryFilter = document.getElementById('categoryFilter');
+    const taskFilter = document.getElementById('taskFilter');
     const tabFilter = document.getElementById('tabFilter');
     const tabLoadingIndicator = document.getElementById('tabLoadingIndicator');
     const tabFilterHelp = document.getElementById('tabFilterHelp');
@@ -314,6 +319,9 @@ document.addEventListener('DOMContentLoaded', async function() {
         if (filters.category) {
             categoryFilter.value = filters.category;
         }
+        if (filters.task) {
+            taskFilter.value = filters.task;
+        }
         if (filters.search) {
             searchFilter.value = filters.search;
         }
@@ -411,6 +419,10 @@ document.addEventListener('DOMContentLoaded', async function() {
         const category = categoryFilter.value.trim();
         if (category) {
             targetFilters.category = parseInt(category, 10);
+        }
+        const task = taskFilter.value.trim();
+        if (task) {
+            targetFilters.task = parseInt(task, 10);
         }
         const tab = tabFilter.value;
         if (tab) {


### PR DESCRIPTION
### Summary 
Implement complete support for myMoment's new category/task structure:

- Database: Add task_filter to MonitoringProcess, article_task_id to AIComment
- Scraper: Update to ID-based mappings, extract category/task from detail HTML
- Service/API: Support task_filter throughout monitoring process lifecycle
- Pipeline: Pass task filtering through discovery and content preparation
- Frontend: Add task filter dropdown to process creation/edit form

Server-side filtering via URL parameters (?kategorie=X&aufgabe=Y) is now the primary approach. Category and task IDs are extracted and stored during content preparation phase for validation and querying.

Breaking changes:
- CATEGORY_MAPPING structure changed from keyword-based to ID-based
- Removed image-based category extraction

### Rationale

#### Background

myMoment has changed how they handle article categorization:

**OLD System (Pre-2026):**
- Categories were extracted from image URLs in article cards (e.g., `/media/2025/2/14/unterhalten.png`)
- "Writing tasks" (Schreibaufgaben like `sa-schaltplan`) were mixed into the category system
- Fragile parsing required, no direct filtering support

**NEW System (Current):**
- **Categories (Kategorien)**: 7 communication functions
  - Anleiten (4)
  - Berichten (14)
  - Erklären (5)
  - Fragen (6)
  - Informieren (7)
  - Überzeugen (8)
  - Unterhalten (9)
- **Tasks (Aufgaben)**: Separate writing assignments
  - Fiktionaler Dialog zwischen zwei Gegenständen (4)
  - Wo ist Hugo? (Anleitung schreiben) (10)
  - (More tasks may exist)
- **Direct URL filtering**: `?tab=home&kategorie=14&aufgabe=10`
- Cleaner, more efficient scraping possible

#### Example HTML Structure

```html
<select name="kategorie" id="kategorie" class="form-select" onchange="this.form.submit()">
    <option value="">Alle Kategorien</option>
    <option value="4">Anleiten</option>
    <option value="14">Berichten</option>
    <!-- ... -->
</select>
<select name="aufgabe" id="aufgabe" class="form-select" onchange="this.form.submit()">
    <option value="">Alle Aufgaben</option>
    <option value="4">Fiktionaler Dialog zwischen zwei Gegenständen</option>
    <option value="10">Wo ist Hugo? (Anleitung schreiben)</option>
</select>
```

#### Benefits of Update

1. **More efficient scraping**: Use URL parameters instead of parsing HTML/images
2. **Granular filtering**: Users can filter by category AND/OR task independently
3. **Future-proof**: Less fragile than image URL parsing
4. **Better UX**: Matches myMoment's current interface

### Notes

- All new fields are `nullable=True` - existing records will have NULL values
- Existing monitoring processes without `task_filter` will continue to work
- Old articles with only `category` will display correctly
- Image-based category extraction was not kept as fallback

1. **Task Information in HTML**: ✅ RESOLVED
   - Task information is NOT exposed in article card HTML on the index view
   - Task filtering is handled entirely server-side via URL parameters (?aufgabe=X)
   - ArticleMetadata.task_id remains None when scraped from index
   - Client-side validation of task_id is not possible

2. **Complete TASK_MAPPING**: Only 2 tasks observed so far
   - These are at the moment indeed all available tasks
   - Needs to be updated in the future
   - How to populate TASK_MAPPING dynamically?
   - Scrape from dropdown on first run?
   - Hardcode initial values and update as needed?
   - Add admin endpoint to refresh task list?

3. **URL Parameter Efficiency**: Will myMoment's server handle filtered requests well?
   - May need rate limiting adjustments
   - Monitor for any blocks or errors

4. **Migration Rollback**: If issues arise, rollback with:
   ```bash
   alembic downgrade -1
   ```

### Decision Log

#### 2026-01-13: Phase 1 Decisions

1. **No `article_task_name` in AIComment**: User requested to store only `article_task_id`, not the name
   - Rationale: Task names can be looked up from TASK_MAPPING if needed
   - Reduces data duplication
   - Saves storage space

2. **Nullable fields**: All new fields are nullable for backward compatibility
   - Existing processes can continue without task_filter
   - Old articles can exist with null article_task_id

3. **Migration ID format**: Used `2026011301` format
   - Date-based: YYYYMMDDNN (2026-01-13, version 01)
   - Clear ordering, avoids conflicts

#### 2026-01-13: Phase 2 Decisions

1. **No `task_name` or `category_name` in ArticleMetadata**: User requested only ID fields
   - Consistent with Phase 1 decision to avoid storing names in database
   - Task names can be looked up from TASK_MAPPING constant
   - Category names can be looked up from CATEGORY_MAPPING constant
   - Reduces data duplication and storage requirements

2. **Server-side filtering only**: Rely on myMoment's URL parameters for filtering
   - URL format: `?tab={tab}&kategorie={category}&aufgabe={task}`
   - More efficient than parsing HTML for task information
   - Reduces scraping load and complexity

3. **No client-side validation**: Cannot validate task_id from article cards
   - Task information not exposed in article card HTML on index view
   - ArticleMetadata.task_id remains None when scraped
   - Trust server-side filtering to return correct results

4. **Keep image-based category extraction**: Marked as deprecated but kept as fallback
   - Provides backward compatibility for older articles
   - Fallback mechanism if server-side filtering fails
   - Can be removed in future version

5. **Removed sa-* entries from CATEGORY_MAPPING**: Tasks are now separate from categories
   - Cleaner separation of concerns
   - Matches myMoment's current platform structure
   - Old sa-* task entries moved to TASK_MAPPING

#### 2026-01-13: Phase 3 Decisions

1. **No validation for task_filter values**: Accept any integer task_filter value
   - Trust the caller to provide valid task IDs
   - Server-side myMoment filtering will handle invalid IDs gracefully
   - Keeps service layer simple and decoupled from task enumeration

2. **Consistent parameter placement**: task_filter placed immediately after category_filter
   - Maintains logical grouping of filter parameters
   - Improves code readability and consistency
   - Mirrors the ordering in MonitoringProcess model

3. **Optional parameter design**: task_filter is Optional[int] with None default
   - Backward compatible with existing code
   - None means no task filtering (all tasks included)
   - Consistent with other filter parameters

#### 2026-01-13: Phase 4 Decisions

1. **No schema changes needed**: Existing `target_filters: Optional[dict]` field already supports task
   - Generic dict type accepts any keys including "task"
   - No validation rules needed at schema level
   - Keeps API flexible for future filter additions

2. **Support both single and array formats**: Extract task from both "task" and "tasks" keys
   - Consistent with category_filter extraction pattern
   - Supports `{"task": 4}` for single value
   - Supports `{"tasks": [4]}` for array format (uses first element)
   - Future-proof for potential multi-task filtering

3. **Extraction before service call**: Parse target_filters at API layer
   - API layer handles dict manipulation and fallbacks
   - Service layer receives clean typed parameters
   - Clear separation of concerns

4. **Consistent placement in update_kwargs**: task_filter placed after category_filter
   - Maintains logical grouping of filter parameters
   - Matches parameter order in service methods
   - Improves code readability

#### 2026-01-13: Phase 5 Decisions

1. **ProcessConfig includes task_filter**: Added task_filter to configuration snapshot
   - Placed between category_filter and search_filter for logical grouping
   - Maintains consistency with model field ordering
   - Enables task filtering throughout the pipeline

2. **Convert task_filter to string for scraper**: Convert integer to string before passing to scraper
   - Scraper expects string parameters for URL construction
   - Pattern matches category_filter conversion: `str(config.category_filter) if config.category_filter else None`
   - Keeps scraper interface consistent

3. **Store article_task_id in AIComment records**: Capture task_id from ArticleMetadata
   - Even though task_id will be None from article cards, store it for future compatibility
   - If task information becomes available in future, database is ready
   - Maintains data integrity and audit trail

4. **Complete data flow**: task_filter flows from process → config → scraper → metadata → database
   - Ensures consistent filtering throughout the entire pipeline
   - Each layer passes task information to the next
   - End-to-end traceability from user input to stored records

#### 2026-01-13: Post-Review Consistency Fix

1. **Removed image-based category extraction at discovery**: Set category_id = None consistently with task_id
   - Previously: category_id extracted from image (deprecated), task_id = None
   - Now: Both category_id = None and task_id = None at discovery
   - **Rationale**: We rely on server-side URL filtering (?kategorie=X&aufgabe=Y) as primary approach
   - Image-based extraction is deprecated and inconsistent with task behavior
   - Both categories and tasks are now determined via server-side filtering only
   - Ensures consistent behavior: what we can't extract for tasks, we don't extract for categories

2. **Updated article parsing comments**: Clarified why both fields are None
   - Documented that server-side filtering is the primary mechanism
   - Explained that image-based extraction is deprecated
   - Made explicit that both fields have consistent behavior

#### 2026-01-13: Content Preparation Enhancement (Phase 5.5)

1. **Updated CATEGORY_MAPPING structure**: Changed from keyword-based to ID-based mapping
   - Old format: `{"keyword": (id, name)}` for image filename matching
   - New format: `{id: name}` consistent with TASK_MAPPING
   - Rationale: Keywords no longer needed since image extraction removed

2. **Removed _extract_category_from_image() method**: Completely removed deprecated method
   - Method relied on old keyword-based mapping
   - No longer used anywhere in codebase (discovery sets None, detail view uses new extractors)
   - Clean removal of dead code

3. **Added extraction from article detail page**: Extract category and task IDs during content preparation
   - New method: `_extract_category_and_task_from_detail(soup)` parses detail page HTML
   - Looks for `<li>Kategorie: Anleiten</li>` and `<li>Aufgabe: Wo ist Hugo?...</li>`
   - Helper methods: `_lookup_category_id()` and `_lookup_task_id()` for reverse lookup
   - Returns tuple: (category_id, task_id) or (None, None) if not found

4. **Updated get_article_content()**: Now returns category_id and task_id
   - Calls `_extract_category_and_task_from_detail()` after fetching HTML
   - Includes category_id and task_id in return dictionary
   - Makes extracted IDs available to content preparation phase

5. **Updated article_preparation.py**: Store extracted IDs in AIComment records
   - Modified `_update_article_content()` to update article_category and article_task_id
   - Updates happen during content preparation phase (after discovery, during detail fetch)
   - Only updates if IDs are present in content_data (handles None gracefully)

**Result**: Complete data flow from discovery to storage
- Discovery phase: category_id=None, task_id=None (consistent, server-filtered)
- Content preparation: Extract from detail HTML, update database with actual IDs
- Database: AIComment records now have accurate category and task information
- Validation: Can verify that server-side filtering worked correctly

#### 2026-01-13: Phase 6 Decisions (Frontend Implementation)

1. **Hardcoded task options in template**: Task dropdown populated with static options
   - Matches TASK_MAPPING from scraper_service.py (tasks 4 and 10)
   - No dynamic loading from backend API
   - Rationale: Only 2 tasks currently known, simpler to hardcode than create API endpoint
   - Future: Add more tasks to dropdown as they are discovered

2. **Single form for create and edit**: Reused existing form.html for both operations
   - Form detects edit mode via `processId` variable
   - Loads existing task filter value when editing
   - Consistent with existing pattern for other filters (category, tab, search)

3. **Task filter optional**: Empty option "Alle Aufgaben" (All tasks) as default
   - Allows users to not filter by task (None value sent to backend)
   - Consistent with category filter behavior
   - Backend handles None gracefully (no task filtering applied)

4. **Integer conversion in JavaScript**: Task value converted to integer before sending
   - `targetFilters.task = parseInt(task, 10)` ensures correct type
   - Matches backend expectation of Optional[int]
   - Prevents type mismatch errors

5. **No task display in list views**: Task filter not shown in monitoring process index or AI comments
   - Rationale: Not critical for overview/list functionality
   - Can be added later if needed for filtering or sorting
   - Keeps UI clean and focused on essential information